### PR TITLE
updates dockerfile and readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 MAINTAINER iconik Media AB <info@iconik.io>
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Usage examples
+
 Build the image first:
 `$ docker build -t docker_isg:latest .`
 
@@ -27,3 +28,71 @@ docker run -it \
 `/home/my_user/isg_local_data` - custom preferred location on host
 for the ISG local database. It is important to mount it as an external
 volume in order to make local database persistent.
+
+## Updating the iconik version
+
+When a new version of iconik Storage Gateway is released, a new Docker image needs to be built and pushed to Docker Hub. The `apt-get install -y iconik-storage-gateway` in the Dockerfile installs the latest available version automatically, so no Dockerfile changes are needed unless the base OS needs upgrading.
+
+### Requirements
+- A Linux **AMD64** machine for building (Apple Silicon Macs cause emulation issues with this image).
+- Docker installed and logged in to Docker Hub with access to the `xpresshd` account.
+
+### Steps
+
+**1. Build the new image**
+
+Tag it with the next version number following the existing convention (e.g. `1_11`, `1_12`):
+
+```bash
+docker login
+docker build -t xpresshd/iconik-storage-gateway-docker-with-redline:1_XX .
+docker push xpresshd/iconik-storage-gateway-docker-with-redline:1_XX
+```
+
+**2. Update the compose file on the server**
+
+SSH into the server and edit the compose file:
+
+```bash
+ssh root@office-server
+vim /mnt/app-pool-1/office-server-compose/services/iconik-storage-gateway/docker-compose.yml
+```
+
+Change the image tag to the new version, e.g.  
+
+`image: xpresshd/iconik-storage-gateway-docker-with-redline:1_XX`  
+
+then run docker compose from location `/mnt/app-pool-1/office-server-compose`:
+
+```bash
+cd /mnt/app-pool-1/office-server-compose
+docker compose pull iconik-storage-gateway
+docker compose up -d iconik-storage-gateway
+```
+
+**3. Verify**
+
+- Check the container is running: `docker ps | grep iconik`
+- Check logs look clean: `docker logs office-iconik-storage-gateway-1`
+- Go to https://app.iconik.io/ -> Admin → Storages -> `office-truenas` and confirm the ISG Version and Scanner Status show as Active and the new version is reflected.
+
+### Rollback
+
+If there are issues with the new image, revert the compose file to the previous tag and run docker compose:
+
+`vim /mnt/app-pool-1/office-server-compose/services/iconik-storage-gateway/docker-compose.yml`
+
+set previous version
+
+`image: xpresshd/iconik-storage-gateway-docker-with-redline:1_XX` 
+
+and
+
+```bash
+cd /mnt/app-pool-1/office-server-compose
+docker compose up -d iconik-storage-gateway
+```
+
+### Notes
+
+- **Docker Hub**: Images are stored at https://hub.docker.com/r/xpresshd/iconik-storage-gateway-docker-with-redline


### PR DESCRIPTION

- update base image  to `ubuntu:jammy`  
iconik Storage Gateway 3.15.11 required GLIBC 2.35, which is not available in Ubuntu 20.04 (focal). The container was crashing on the server with the following error:
  ```
  Error loading Python lib: dlopen: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found
  ```
  upgrading the base image to Ubuntu 22.04 (jammy) resolves this.

- update README with instructions for future maintainers

Fixes: https://github.com/xpresshd/office-server-compose/issues/20